### PR TITLE
Explicitly check that the resolved file exists

### DIFF
--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 
-import image from '&/assets/image.svg'
+import image from '@test/assets/image.svg'
 
 const mode = import.meta.env.MODE
 
@@ -13,7 +13,7 @@ const mode = import.meta.env.MODE
   <img :src="image" alt="manually imported" />
 
   <h1>Directly referenced static asset</h1>
-  <img src="&/assets/image.svg" alt="direct-reference"/>
+  <img src="@test/assets/image.svg" alt="direct-reference"/>
 </template>
 
 <style scoped>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,9 +11,9 @@ export default defineConfig({
     {
       name: 'branding-resolver',
       async resolveId(source, importer, options) {
-        if (source.startsWith('&')) {
-          const brandedPath = source.replace('&', `@/${process.env.VITE_SKIN}`)
-          const defaultPath = source.replace('&', `@/shared`)
+        if (source.startsWith('@test')) {
+          const brandedPath = source.replace('@test', `@/${process.env.VITE_SKIN}`)
+          const defaultPath = source.replace('@test', `@/shared`)
 
           const brandedModule = await this.resolve(brandedPath, importer, options)
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { fileURLToPath, URL } from 'url'
+import fs from 'fs'
+
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -15,7 +17,7 @@ export default defineConfig({
 
           const brandedModule = await this.resolve(brandedPath, importer, options)
 
-          if (brandedModule) {
+          if (brandedModule && fs.existsSync(brandedModule.id)) {
             return brandedModule
           }
 


### PR DESCRIPTION
It looks like in the vue context, for some reason the result of

`await this.resolve(brandedPath, importer, options)`

is

```js
{
  id: '/Users/alex/code/processed-static-imports-vite-vue/src/undefined/assets/image.svg'
}
```

instead of `null`. So let's explicitly check that the resolved skinned file exists.